### PR TITLE
feat: Add link checker workflow for documentation

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,33 @@
+name: Link Checker
+
+on:
+  # Run on PRs and pushes to develop and main
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  # Run weekly to catch any external links that might break
+  schedule:
+    - cron: '0 0 * * 0'  # Run at 00:00 every Sunday
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+          args: --verbose --no-progress './**/*.md' './**/*.html'
+          fail: true
+
+      - name: Create Issue From File
+        if: failure()
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: |
+            🔍 Type: Documentation
+            ⚠️ Status: Blocked 

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -4,11 +4,17 @@ on:
   # Run on PRs and pushes to develop and main
   push:
     branches: [ main, develop ]
+    paths:
+      - 'docs/**'
+      - '*.md'
   pull_request:
     branches: [ main, develop ]
-  # Run weekly to catch any external links that might break
+    paths:
+      - 'docs/**'
+      - '*.md'
+  # Monthly check for documentation links
   schedule:
-    - cron: '0 0 * * 0'  # Run at 00:00 every Sunday
+    - cron: '0 0 1 * *'  # Run at midnight on the first day of each month
 
 jobs:
   linkChecker:
@@ -19,15 +25,23 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.8.0
         with:
-          args: --verbose --no-progress './**/*.md' './**/*.html'
+          args: >-
+            --verbose
+            --no-progress
+            --exclude-all-private
+            --exclude "^(?!http).*"
+            --exclude "^tel:"
+            --max-retries 3
+            --timeout 30
+            './docs/**/*.md'
+            './*.md'
           fail: true
 
       - name: Create Issue From File
-        if: failure()
+        if: failure() && github.event_name == 'schedule'
         uses: peter-evans/create-issue-from-file@v4
         with:
-          title: Link Checker Report
+          title: Monthly Documentation Link Check Report
           content-filepath: ./lychee/out.md
           labels: |
-            🔍 Type: Documentation
-            ⚠️ Status: Blocked 
+            🔍 Type: Documentation 


### PR DESCRIPTION
This PR adds a streamlined link checker workflow focused specifically on documentation maintenance.

### Features
- Checks links in documentation files only (`docs/**/*.md` and root `*.md` files)
- Runs on two triggers:
  1. When documentation files are modified in PRs/pushes to `main` and `develop`
  2. Monthly maintenance check (first day of each month)

### Implementation Details
- Uses `lychee-action` configured for reliability:
  - Retries up to 3 times for transient failures
  - 30-second timeout per request
  - Excludes non-HTTP links and private repositories
  - Only checks actual documentation files
- Creates issues only for monthly checks to reduce noise
- Fails PR checks immediately if broken links are found

### Benefits
- Focused scope: Only checks what matters
- Less noisy: Issues created only for monthly checks
- More reliable: Configured to avoid false positives
- Low maintenance: Automated but not intrusive

### Testing Notes
- The workflow will run on this PR since it modifies documentation paths
- You can monitor the workflow in the Actions tab